### PR TITLE
TXMNT-827 integrate usage of wrapped ES client into ALS

### DIFF
--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -30,7 +30,7 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "logback-json-logger" % "3.1.0",
     "uk.gov.hmrc" %% "domain" % "4.1.0",
     "uk.gov.hmrc" %% "logging" % "0.4.0" withSources(),
-    "uk.gov.hmrc" %% "address-reputation-store" % "2.25.0" withSources(),
+    "uk.gov.hmrc" %% "address-reputation-store" % "2.28.0" withSources(),
     "uk.gov.hmrc" %% "play-random-json-filter" % "0.3.0",
     "com.univocity" % "univocity-parsers" % "1.5.6",
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,

--- a/test/unit/osgb/ElasticsearchSketch.scala
+++ b/test/unit/osgb/ElasticsearchSketch.scala
@@ -41,11 +41,11 @@ object ElasticsearchSketch {
     val numShards = Map.empty[String, Int]
 
     val settings = ElasticSettings(false, None, false, connectionString, isCluster, clusterName, numShards)
-    val clients = ElasticsearchHelper.buildClients(settings, new LoggerFacade(Logger.logger))
-    val esImpl = new ESAdminImpl(clients, logger, ec)
+    val clients = ElasticsearchHelper.buildClients(settings, logger)
+    val esImpl = new ESAdminImpl(clients, logger, ec, settings)
     val indexMetadata: IndexMetadata = new IndexMetadata(esImpl, isCluster, numShards, logger, ec)
 
-    val searcher = new AddressESSearcher(indexMetadata.clients.head, indexName, "GB", ec)
+    val searcher = new AddressESSearcher(indexMetadata.clients.head, indexName, "GB", ec, settings, logger)
 
     idSample("GB123456", searcher)
     uprnSample("123456", searcher)


### PR DESCRIPTION
This commit updates the version of address-reputation-store and integrates usage of the recently added reconnecting client wrapper into the ES address searcher in ALS