### PR TITLE
fix: address object array limits #78

### DIFF
--- a/public/api/conf/1.0/docs/uk-address-object.json
+++ b/public/api/conf/1.0/docs/uk-address-object.json
@@ -41,8 +41,8 @@
                             "minLength": 1,
                             "maxLength": 35
                         },
-                        "minLength": 1,
-                        "maxLength": 3
+                        "minItems": 1,
+                        "maxItems": 3
                     },
                     "town": {
                         "type": "string",


### PR DESCRIPTION
Included the limits for the array to limit the number of lines it would allow