### PR TITLE
CIR 1651

### DIFF
--- a/app/config/InvalidJsonErrorHandler.scala
+++ b/app/config/InvalidJsonErrorHandler.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import play.api.Configuration
+import play.api.http.Status.{BAD_REQUEST, NOT_FOUND}
+import play.api.libs.json.Json
+import play.api.libs.json.Json.toJson
+import play.api.mvc.Results.{BadRequest, NotFound, Status}
+import play.api.mvc.{RequestHeader, Result}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
+import uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class InvalidJsonErrorHandler @Inject()(
+                                         auditConnector: AuditConnector, httpAuditEvent: HttpAuditEvent, configuration: Configuration
+                                       )(implicit ec: ExecutionContext)
+  extends uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler(auditConnector, httpAuditEvent, configuration) {
+  import httpAuditEvent._
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    implicit val headerCarrier: HeaderCarrier = hc(request)
+    val result = statusCode match {
+      case NOT_FOUND =>
+        auditConnector.sendEvent(
+          dataEvent(
+            eventType       = "ResourceNotFound",
+            transactionName = "Resource Endpoint Not Found",
+            request         = request,
+            detail          = Map.empty
+          )
+        )
+        NotFound(toJson(ErrorResponse(NOT_FOUND, "URI not found", requested = Some(request.path))))
+
+      case BAD_REQUEST =>
+        auditConnector.sendEvent(
+          dataEvent(
+            eventType       = "ServerValidationError",
+            transactionName = "Request bad format exception",
+            request         = request,
+            detail          = Map.empty
+          )
+        )
+        def constructErrorMessage(input: String): String = {
+          val unrecognisedTokenJsonError = "^Invalid Json: Unrecognized token '(.*)':.*".r
+          val invalidJson                = "^(?s)Invalid Json:.*".r
+          val jsonValidationError        = "^Json validation error.*".r
+          val booleanParsingError        = "^Cannot parse parameter .* as Boolean: should be true, false, 0 or 1$".r
+          val missingParameterError      = "^Missing parameter:.*".r
+          val characterParseError        = "^Cannot parse parameter .* with value '(.*)' as Char: .* must be exactly one digit in length.$".r
+          val parameterParseError        = "^Cannot parse parameter .* as .*: For input string: \"(.*)\"$".r
+          input match {
+            case unrecognisedTokenJsonError(toBeRedacted) => input.replace(toBeRedacted, "REDACTED")
+            case invalidJson()
+                 | jsonValidationError()
+                 | booleanParsingError()
+                 | missingParameterError()                  => filterJsonExceptionMsg(input)
+            case characterParseError(toBeRedacted)        => input.replace(toBeRedacted, "REDACTED")
+            case parameterParseError(toBeRedacted)        => input.replace(toBeRedacted, "REDACTED")
+            case _                                        => "bad request, cause: REDACTED"
+          }
+        }
+        val msg =
+          if (suppress4xxErrorMessages) "Bad request"
+          else constructErrorMessage(message)
+
+        BadRequest(toJson(ErrorResponse(BAD_REQUEST, msg)))
+
+      case _ =>
+        auditConnector.sendEvent(
+          dataEvent(
+            eventType       = "ClientError",
+            transactionName = s"A client error occurred, status: $statusCode",
+            request         = request,
+            detail          = Map.empty
+          )
+        )
+
+        val msg =
+          if (suppress4xxErrorMessages) "Other error"
+          else message
+
+        Status(statusCode)(toJson(ErrorResponse(statusCode, msg)))
+    }
+    Future.successful(result)
+  }
+
+  private def filterJsonExceptionMsg(msg: String): String = {
+    msg.indexOf("at [Source") match {
+      case -1 => msg
+      case x => msg.substring(0, x)
+    }
+  }
+}

--- a/app/connectors/DownstreamConnector.scala
+++ b/app/connectors/DownstreamConnector.scala
@@ -38,10 +38,10 @@ class DownstreamConnector @Inject()(httpClient: HttpClient) extends Logging {
     logger.info(s"Forwarding to downstream url: $url")
 
     // TODO: Check if the context path is present - if so remove before forwarding
-    val called = (request.method, request.headers.get(CONTENT_TYPE).map(_.toLowerCase())) match {
-      case ("POST", Some("application/json")) =>
+    val called = request.method match {
+      case "POST" =>
         httpClient.POST[Option[JsValue], HttpResponse](url = url, body = Some(request.body), onwardHeaders)
-      case ("GET", _)                         =>
+      case "GET"  =>
         httpClient.GET[HttpResponse](url = url, onwardHeaders)
     }
 

--- a/app/model/request.scala
+++ b/app/model/request.scala
@@ -74,6 +74,13 @@ object request {
     implicit val writes: Writes[LookupByPostTownRequest] = Json.writes[LookupByPostTownRequest]
   }
 
+  case class LookupByCountryFilterRequest(filter: String)
+
+  object LookupByCountryFilterRequest {
+    implicit val reads: Reads[LookupByCountryFilterRequest] = Json.reads[LookupByCountryFilterRequest]
+    implicit val writes: Writes[LookupByCountryFilterRequest] = Json.writes[LookupByCountryFilterRequest]
+  }
+
   case class LookupByCountryRequest(country: String, filter: String)
 
   object LookupByCountryRequest {

--- a/app/util/package.scala
+++ b/app/util/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,7 @@ header.x-origin = "X-LOCALHOST-Origin"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 
 # Json error handler
-play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
+play.http.errorHandler = "config.InvalidJsonErrorHandler"
 
 # Address Lookup module
 play.modules.enabled += "Module"

--- a/it/test/suites/CountryLookupSuiteV2.scala
+++ b/it/test/suites/CountryLookupSuiteV2.scala
@@ -26,6 +26,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
+import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
@@ -89,6 +90,15 @@ class CountryLookupSuiteV2()
             NonUKAddressSearchAuditEventMatchedAddress(Some("BM1fb321218785e9a6"), Some("12"), Some("Arlington Avenue"), None, None, Some("Pembroke"), None, Some("HM02"), "bm")))
         Mockito.verify(auditConnector).sendExplicitAudit(meq("NonUKAddressSearch"), meq(expectedAuditValues))(any(),any(),any())
       }
+
+      "give a successful response for bermuda with text content-type" in {
+        val response = post("/country/BM/lookup", """{"filter":"HM02"}""", MimeTypes.TEXT)
+
+        val contentType = response.header("Content-Type").get
+        contentType should startWith("application/json")
+
+        response.status shouldBe OK
+    }
 
       "give a successful response for an unknown postcode" in {
         val response = post("/country/BM/lookup", """{"filter":"HM99"}""")

--- a/it/test/suites/CountryLookupSuiteV2.scala
+++ b/it/test/suites/CountryLookupSuiteV2.scala
@@ -20,16 +20,17 @@ import com.codahale.metrics.SharedMetricRegistries
 import it.helper.AppServerTestApi
 import model.address.NonUKAddress
 import model.{NonUKAddressSearchAuditEvent, NonUKAddressSearchAuditEventMatchedAddress, NonUKAddressSearchAuditEventRequestDetails}
+import org.apache.pekko.util.ByteString
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
-import play.api.http.MimeTypes
+import play.api.http.{HeaderNames, MimeTypes}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
-import play.api.libs.ws.WSClient
+import play.api.libs.ws.{InMemoryBody, WSClient}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.inject.Bindings
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
@@ -91,15 +92,6 @@ class CountryLookupSuiteV2()
         Mockito.verify(auditConnector).sendExplicitAudit(meq("NonUKAddressSearch"), meq(expectedAuditValues))(any(),any(),any())
       }
 
-      "give a successful response for bermuda with text content-type" in {
-        val response = post("/country/BM/lookup", """{"filter":"HM02"}""", MimeTypes.TEXT)
-
-        val contentType = response.header("Content-Type").get
-        contentType should startWith("application/json")
-
-        response.status shouldBe OK
-    }
-
       "give a successful response for an unknown postcode" in {
         val response = post("/country/BM/lookup", """{"filter":"HM99"}""")
         response.status shouldBe OK
@@ -143,7 +135,13 @@ class CountryLookupSuiteV2()
 
       "return forbidden when the user-agent is absent" in {
         val path = "/country/GB/lookup"
-        val response = await(wsClient.url(appEndpoint + path).withMethod("POST").withBody("""{"filter":"FX1 4AB"}""").execute())
+        val response = await(
+          wsClient
+            .url(appEndpoint + path)
+            .withMethod("POST")
+            .withHttpHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+            .withBody("""{"filter":"FX1 4AB"}""")
+            .execute())
         response.status shouldBe FORBIDDEN
       }
 
@@ -162,6 +160,22 @@ class CountryLookupSuiteV2()
       "give a bad method when using GET to the address URL" ignore {
         val response = request("GET", "/country/GB/lookup?postcode=FX1+9PY", headerOrigin -> "xxx")
         response.status shouldBe METHOD_NOT_ALLOWED
+      }
+
+      "give an unsupported media type response for bermuda with text content-type" in {
+        // Have to define this as the withHttpHeaders doesn't seem to be replacing existing headers.
+        def pst(path: String, body: String): play.api.libs.ws.WSResponse = {
+          val wsBody = InMemoryBody(ByteString(body.trim))
+          val req = newRequest("POST", path)
+            .withHttpHeaders("Content-Type" -> "plain/text")
+            .withBody(wsBody)
+
+          await(req.execute("POST"))
+        }
+
+        val response = pst(path = "/country/BM/lookup", body = """{"filter":"HM02"}""")
+
+        response.status shouldBe UNSUPPORTED_MEDIA_TYPE
       }
     }
   }

--- a/it/test/suites/LookupPostSuite.scala
+++ b/it/test/suites/LookupPostSuite.scala
@@ -24,7 +24,7 @@ import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 
@@ -160,8 +160,9 @@ class LookupPostSuite()
       "give a bad request when the postcode parameter is absent" in {
         val response = post("/lookup", "{}")
         response.status shouldBe BAD_REQUEST
-        response.body shouldBe """{"obj.postcode":[{"msg":["error.path.missing"],"args":[]}]}"""
-      }
+        val jsonBody = response.body[JsValue]
+        (jsonBody \ "statusCode").as[Int] shouldBe BAD_REQUEST
+        (jsonBody \ "message").as[String] should startWith("Json validation error")      }
 
       "give a bad request when the postcode parameter is rubbish text" in {
         val payload =
@@ -171,8 +172,9 @@ class LookupPostSuite()
 
         val response = post("/lookup", payload)
         response.status shouldBe BAD_REQUEST
-        response.body shouldBe """{"obj.postcode":[{"msg":["error.invalid"],"args":[]}]}"""
-      }
+        val jsonBody = response.body[JsValue]
+        (jsonBody \ "statusCode").as[Int] shouldBe BAD_REQUEST
+        (jsonBody \ "message").as[String] should startWith("Json validation error")      }
 
       "give a bad request when the postcode parameter is of the wrong type" in {
         val payload =
@@ -182,8 +184,9 @@ class LookupPostSuite()
 
         val response = post("/lookup", payload)
         response.status shouldBe BAD_REQUEST
-        response.body shouldBe """{"obj.postcode":[{"msg":["error.expected.jsstring"],"args":[]}]}"""
-      }
+        val jsonBody = response.body[JsValue]
+        (jsonBody \ "statusCode").as[Int] shouldBe BAD_REQUEST
+        (jsonBody \ "message").as[String] should startWith("Json validation error")      }
 
       "give a bad request when an unexpected parameter is sent on its own" in {
         val payload =
@@ -193,8 +196,9 @@ class LookupPostSuite()
 
         val response = post("/lookup", payload)
         response.status shouldBe BAD_REQUEST
-        response.body shouldBe """{"obj.postcode":[{"msg":["error.path.missing"],"args":[]}]}"""
-      }
+        val jsonBody = response.body[JsValue]
+        (jsonBody \ "statusCode").as[Int] shouldBe BAD_REQUEST
+        (jsonBody \ "message").as[String] should startWith("Json validation error")      }
 
       "not give a bad request when an unexpected parameter is sent" in {
         val payload =

--- a/it/test/suites/LookupPostSuite.scala
+++ b/it/test/suites/LookupPostSuite.scala
@@ -22,6 +22,7 @@ import model.address.AddressRecord
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
+import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
@@ -54,6 +55,14 @@ class LookupPostSuite()
           """{"postcode": "fx1 9py"}""".stripMargin
 
         val response = post("/lookup", payload)
+        response.status shouldBe OK
+      }
+
+      "give a successful response for a known postcode with text content-type - uk route" in {
+        val payload =
+          """{"postcode": "fx1 9py"}""".stripMargin
+
+        val response = post("/lookup", payload, MimeTypes.TEXT)
         response.status shouldBe OK
       }
 

--- a/it/test/suites/PostcodeLookupSuiteV2.scala
+++ b/it/test/suites/PostcodeLookupSuiteV2.scala
@@ -27,6 +27,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
+import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, JsObject, Json}
 import play.api.libs.ws.WSClient
@@ -59,6 +60,13 @@ class PostcodeLookupSuiteV2()
 
       "give a successful response for a known postcode - uk route" in {
         val response = post("/lookup", """{"postcode":"AA00 0AA"}""")
+        response.status shouldBe OK
+        val jsonBody = Json.parse(response.body)
+        jsonBody shouldBe a[JsArray]
+      }
+
+      "give a successful response for a known postcode with text content type - uk route" in {
+        val response = post("/lookup", """{"postcode":"AA00 0AA"}""", MimeTypes.TEXT)
         response.status shouldBe OK
         val jsonBody = Json.parse(response.body)
         jsonBody shouldBe a[JsArray]

--- a/it/test/suites/TownLookupPostSuite.scala
+++ b/it/test/suites/TownLookupPostSuite.scala
@@ -24,7 +24,7 @@ import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{JsArray, Json}
+import play.api.libs.json.{JsArray, JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 
@@ -192,7 +192,9 @@ class TownLookupPostSuite()
       "give a bad request when the town parameter is absent" in {
         val response = post("/lookup/by-post-town", "{}")
         response.status shouldBe BAD_REQUEST
-        response.body shouldBe """{"obj.posttown":[{"msg":["error.path.missing"],"args":[]}]}"""
+        val jsonBody = response.body[JsValue]
+        (jsonBody \ "statusCode").as[Int] shouldBe BAD_REQUEST
+        (jsonBody \ "message").as[String] should startWith("Json validation error")
       }
 
       "give a bad request when the town parameter is of the wrong type" in {
@@ -203,7 +205,9 @@ class TownLookupPostSuite()
 
         val response = post("/lookup/by-post-town", payload)
         response.status shouldBe BAD_REQUEST
-        response.body shouldBe """{"obj.posttown":[{"msg":["error.expected.jsstring"],"args":[]}]}"""
+        val jsonBody = response.body[JsValue]
+        (jsonBody \ "statusCode").as[Int] shouldBe BAD_REQUEST
+        (jsonBody \ "message").as[String] should startWith("Json validation error")
       }
 
       "give a bad request when an unexpected parameter is sent on its own" in {
@@ -214,7 +218,9 @@ class TownLookupPostSuite()
 
         val response = post("/lookup/by-post-town", payload)
         response.status shouldBe BAD_REQUEST
-        response.body shouldBe """{"obj.posttown":[{"msg":["error.path.missing"],"args":[]}]}"""
+        val jsonBody = response.body[JsValue]
+        (jsonBody \ "statusCode").as[Int] shouldBe BAD_REQUEST
+        (jsonBody \ "message").as[String] should startWith("Json validation error")
       }
 
       "not give a bad request when an unexpected parameter is sent" in {

--- a/it/test/suites/TownLookupPostSuite.scala
+++ b/it/test/suites/TownLookupPostSuite.scala
@@ -22,6 +22,7 @@ import model.address.AddressRecord
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
+import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, Json}
 import play.api.libs.ws.WSClient
@@ -53,6 +54,15 @@ class TownLookupPostSuite()
           """{"posttown": "some-town"}""".stripMargin
 
         val response = post("/lookup/by-post-town", payload)
+        response.status shouldBe OK
+      }
+
+      "give a successful response for a known town with text content-type - uk route" in {
+
+        val payload =
+          """{"posttown": "some-town"}""".stripMargin
+
+        val response = post("/lookup/by-post-town", payload, MimeTypes.TEXT)
         response.status shouldBe OK
       }
 

--- a/it/test/suites/UprnLookupPostSuite.scala
+++ b/it/test/suites/UprnLookupPostSuite.scala
@@ -22,6 +22,7 @@ import model.address.{Address, AddressRecord, Country, LocalCustodian}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
+import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, Json}
 import play.api.libs.ws.WSClient
@@ -63,6 +64,16 @@ class UprnLookupPostSuite()
         arr.size shouldBe 1
         val address1 = Json.fromJson[AddressRecord](arr.head).get
         address1 shouldBe expectedAddressRecord
+      }
+
+      "give a successful response for a known uprn with text content-type - uk route" in {
+        val expectedAddressRecord = AddressRecord(
+          "GB690091234501",Some(690091234501L),None,None,None,
+          Address(List("1 Test Street"),"Testtown","AA00 0AA",Some(Country("GB-ENG","England")),Country("GB","United Kingdom"))
+          ,"en",Some(LocalCustodian(121,"NORTH SOMERSET")),None,None,None)
+
+        val response = post("/lookup/by-uprn", """{"uprn": "690091234501"}""", MimeTypes.TEXT)
+        response.status shouldBe OK
       }
 
       "set the content type to application/json" in {

--- a/it/test/suites/UprnLookupPostSuite.scala
+++ b/it/test/suites/UprnLookupPostSuite.scala
@@ -22,7 +22,7 @@ import model.address.{Address, AddressRecord, Country, LocalCustodian}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
-import play.api.http.MimeTypes
+import play.api.http.{HeaderNames, MimeTypes}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, Json}
 import play.api.libs.ws.WSClient
@@ -107,7 +107,13 @@ class UprnLookupPostSuite()
 
       "return forbidden when the user-agent is absent" in {
         val path = "/lookup/by-uprn"
-        val response = await(wsClient.url(appEndpoint + path).withMethod("POST").withBody("""{"uprn":"9999999999"}""").execute())
+        val response = await(
+          wsClient
+            .url(appEndpoint + path)
+            .withMethod("POST")
+            .withHttpHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+            .withBody("""{"uprn":"9999999999"}""")
+            .execute())
         response.status shouldBe FORBIDDEN
       }
 

--- a/it/test/suites/UprnLookupSuiteV2.scala
+++ b/it/test/suites/UprnLookupSuiteV2.scala
@@ -22,7 +22,7 @@ import model.address.{Address, AddressRecord, Country, LocalCustodian}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
-import play.api.http.MimeTypes
+import play.api.http.{HeaderNames, MimeTypes}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, Json}
 import play.api.libs.ws.WSClient
@@ -107,7 +107,12 @@ class UprnLookupSuiteV2()
 
       "return forbidden when the user-agent is absent" in {
         val path = "/lookup/by-uprn"
-        val response = await(wsClient.url(appEndpoint + path).withMethod("POST").withBody("""{"uprn":"9999999999"}""").execute())
+        val response = await(
+          wsClient
+            .url(appEndpoint + path)
+            .withMethod("POST")
+            .withHttpHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+            .withBody("""{"uprn":"9999999999"}""").execute())
         response.status shouldBe FORBIDDEN
       }
 

--- a/it/test/suites/UprnLookupSuiteV2.scala
+++ b/it/test/suites/UprnLookupSuiteV2.scala
@@ -22,6 +22,7 @@ import model.address.{Address, AddressRecord, Country, LocalCustodian}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
+import play.api.http.MimeTypes
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, Json}
 import play.api.libs.ws.WSClient
@@ -63,6 +64,16 @@ class UprnLookupSuiteV2()
         arr.size shouldBe 1
         val address1 = Json.fromJson[AddressRecord](arr.head).get
         address1 shouldBe expectedAddressRecord
+      }
+
+      "give a successful response for a known uprn with text content-type - uk route" in {
+        val expectedAddressRecord = AddressRecord(
+          "GB690091234501",Some(690091234501L),None,None,None,
+          Address(List("1 Test Street"),"Testtown","AA00 0AA",Some(Country("GB-ENG","England")),Country("GB","United Kingdom"))
+          ,"en",Some(LocalCustodian(121,"NORTH SOMERSET")),None,None,None)
+
+        val response = post("/lookup/by-uprn", """{"uprn":"690091234501"}""", MimeTypes.TEXT)
+        response.status shouldBe OK
       }
 
       "set the content type to application/json" in {

--- a/test/controllers/AddressSearchControllerTest.scala
+++ b/test/controllers/AddressSearchControllerTest.scala
@@ -83,11 +83,10 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
       clearInvocations(mockAuditConnector)
 
 
-      val jsonPayload = Json.toJson(LookupByPostTownRequest("Testtown", Some("Test Street")))
+      val payload = LookupByPostTownRequest("Testtown", Some("Test Street"))
       val request = FakeRequest("POST", "/lookup/by-post-town")
-        .withBody(jsonPayload.toString)
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "forbidden-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-        .withHeadersOrigin
 
       val result = controller.searchByPostTown().apply(request)
       contentType(result) shouldBe Some(MimeTypes.JSON)
@@ -106,9 +105,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
       clearInvocations(mockAuditConnector)
 
 
-      val jsonPayload = Json.toJson(LookupByPostTownRequest("town", Some("address lines")))
+      val payload = LookupByPostTownRequest("town", Some("address lines"))
       val request = FakeRequest("POST", "/lookup/by-post-town")
-        .withBody(jsonPayload.toString)
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
         .withHeadersOrigin
 
@@ -134,9 +133,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
       clearInvocations(mockAuditConnector)
 
 
-      val jsonPayload = Json.toJson(LookupByPostTownRequest("non-existent-town", None))
+      val payload = LookupByPostTownRequest("non-existent-town", None)
       val request = FakeRequest("POST", "/lookup/by-post-town")
-        .withBody(jsonPayload.toString)
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
         .withHeadersOrigin
 
@@ -153,10 +152,11 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
        it should give a forbidden response and not log any error
       """ in {
       import LookupByPostcodeRequest._
-      val jsonPayload = Json.toJson(LookupByPostcodeRequest(Postcode("FX11 4HG")))
-      val request: Request[String] = FakeRequest("POST", "/lookup")
+
+      val payload = LookupByPostcodeRequest(Postcode("FX11 4HG"))
+      val request = FakeRequest("POST", "/lookup")
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "forbidden-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-        .withBody(jsonPayload.toString())
 
       val result = controller.searchByPostcode().apply(request)
       status(result) shouldBe Status.FORBIDDEN
@@ -169,9 +169,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
        and log the lookup including the size of the result list
       """ in {
       clearInvocations(mockAuditConnector)
-      val jsonPayload = Json.toJson(LookupByPostcodeRequest(Postcode("FX11 4HG"), Some("FOO")))
+      val payload = LookupByPostcodeRequest(Postcode("FX11 4HG"), Some("FOO"))
       val request = FakeRequest("POST", "/lookup")
-        .withBody(jsonPayload.toString)
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
         .withHeadersOrigin
 
@@ -185,9 +185,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
        and log the lookup including the size of the result list
       """ in {
       clearInvocations(mockAuditConnector)
-      val jsonPayload = Json.toJson(LookupByPostcodeRequest(Postcode("FX11 4HG"), None))
+      val payload = LookupByPostcodeRequest(Postcode("FX11 4HG"), None)
       val request = FakeRequest("POST", "/lookup")
-        .withBody(jsonPayload.toString)
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
         .withHeadersOrigin
 
@@ -202,9 +202,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
       """ in {
       clearInvocations(mockAuditConnector)
 
-      val jsonPayload = Json.toJson(LookupByPostcodeRequest(Postcode("ZZ11 1ZZ"), Some("Test Street")))
+      val payload = LookupByPostcodeRequest(Postcode("ZZ11 1ZZ"), Some("Test Street"))
       val request = FakeRequest("POST", "/lookup")
-        .withBody(jsonPayload.toString)
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
         .withHeadersOrigin
 
@@ -237,9 +237,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
       """ in {
       clearInvocations(mockAuditConnector)
 
-      val jsonPayload = Json.toJson(LookupByPostcodeRequest(Postcode("ZZ11 1YY")))
+      val payload = LookupByPostcodeRequest(Postcode("ZZ11 1YY"))
       val request = FakeRequest("POST", "/lookup")
-        .withBody(jsonPayload.toString)
+        .withBody(payload)
         .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
         .withHeadersOrigin
 
@@ -255,9 +255,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
     "give forbidden" when {
       """search is called without a valid user agent""" in {
         import LookupByUprnRequest._
-        val jsonPayload = Json.toJson(LookupByUprnRequest("0123456789"))
+        val payload = LookupByUprnRequest("0123456789")
         val request = FakeRequest("POST", "/lookup/by-uprn")
-          .withBody(jsonPayload.toString)
+          .withBody(payload)
           .withHeaders(HeaderNames.USER_AGENT -> "forbidden-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
           .withHeadersOrigin
 
@@ -280,9 +280,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
 
         val expectedAuditEvent = AddressSearchAuditEvent(Some("test-user-agent"), expectedAuditRequestDetails, 10, expectedAuditAddressMatches)
 
-        val jsonPayload = Json.toJson(LookupByUprnRequest("790091234501"))
+        val payload = LookupByUprnRequest("790091234501")
         val request = FakeRequest("POST", "/lookup/by-uprn")
-          .withBody(jsonPayload.toString)
+          .withBody(payload)
           .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
           .withHeadersOrigin
 
@@ -299,9 +299,9 @@ class AddressSearchControllerTest extends AnyWordSpec with Matchers with GuiceOn
         val connector = app.injector.instanceOf[DownstreamConnector]
         val configHelper = app.injector.instanceOf[AppConfig]
         val controller = new AddressSearchController(connector, mockAuditConnector, cc, configHelper)(ec)
-        val jsonPayload = Json.toJson(LookupByUprnRequest("GB0123456789"))
+        val payload = LookupByUprnRequest("GB0123456789")
         val request = FakeRequest("POST", "/lookup/by-uprn")
-          .withBody(jsonPayload.toString)
+          .withBody(payload)
           .withHeaders(HeaderNames.USER_AGENT -> "test-user-agent", HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
           .withHeadersOrigin
 


### PR DESCRIPTION
- **CIR-1615: [FIX] The content type in the downstream connector is too strict. It asserts that the content-type should be application/json but the payload has already been converted to json by this stage. So, remove the content-type check.**
- **CIR-1651: Move to expecting `application/json` content for each request.**
